### PR TITLE
Corrected typo in ieee preprocessing object

### DIFF
--- a/src/fdb/preprocessing_objects.py
+++ b/src/fdb/preprocessing_objects.py
@@ -30,7 +30,7 @@ def load_data(key):
             event_id_col = None
         )
 
-    elif key == 'ieee':
+    elif key == 'ieeecis':
         obj = IEEEPreProcessor(
             key = key,
             train_percentage = 0.95,


### PR DESCRIPTION
In preprocessing objects, key was `ieee`, while it should be `ieeecis`